### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/saas-pro/fire/security/code-scanning/1](https://github.com/saas-pro/fire/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job. This block will specify the least privileges required for the job, which, in this case, is `contents: read`. This ensures the workflow does not inherit potentially excessive default permissions from the repository settings and limits the scope of the `GITHUB_TOKEN` appropriately.

The changes are localized to the `.github/workflows/generator-generic-ossf-slsa3-publish.yml` file, specifically within the `build` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to explicitly allow read access to repository contents during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->