### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/saas-pro/hustloop/security/code-scanning/1](https://github.com/saas-pro/hustloop/security/code-scanning/1)

To fix the issue, explicitly add a `permissions` block to the `build` job in `.github/workflows/generator-generic-ossf-slsa3-publish.yml`. Place it directly under `runs-on:` (line 21) so that it applies to this job only. Set to the minimum required for the job: `contents: read`. This limits the GITHUB_TOKEN to read-only access to repository content for this job, which is sufficient for checking out the code and reading files. No other permissions are required for hashing files or local file system operations. No changes are needed elsewhere in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Hardened CI workflow permissions by explicitly setting the build job to read-only repository access, aligning with least-privilege practices.
  * Provenance job permissions remain unchanged.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->